### PR TITLE
- Upgrades libraries to latest Akka and Scala versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 /bin/
+
+#VSCode
+.metals
+.bloop

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
-version in ThisBuild:= "0.3.2"
+version in ThisBuild:= "0.3.3"
 
-val AkkaVersion = "2.5.16"
+val AkkaVersion = "2.5.25"
 
 val Core = Seq(
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1", /*    */ // BSD 3-clause
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2", /*    */ // BSD 3-clause
   "com.typesafe.akka" %% "akka-actor" /*              */ % AkkaVersion, /* */ // ApacheV2
   "org.slf4j" /*         */ % "slf4j-api" /*          */ % "1.7.25", /*   */ // MIT
   //
-  "org.scalatest" /*    */ %% "scalatest" /*          */ % "3.0.3" % Test, // ApacheV2
+  "org.scalatest" /*    */ %% "scalatest" /*          */ % "3.0.8" % Test, // ApacheV2
   "com.typesafe.akka" %% "akka-testkit" /*            */ % AkkaVersion % Test, // ApacheV2
   "org.slf4j" /*         */ % "slf4j-simple" /*       */ % "1.7.25" % Test // MIT
 )
@@ -20,7 +20,7 @@ val Streams = Core ++ Seq(
 
 
 lazy val common = Seq(
-  crossScalaVersions := Seq("2.11.11", "2.12.2"),
+  crossScalaVersions := Seq("2.11.12", "2.12.9", "2.13.0"),
   //
   organization := "me.lightspeed7",
   //
@@ -40,7 +40,6 @@ lazy val common = Seq(
     "-unchecked",
     //  "-Xfatal-warnings",
     "-Xlint",
-    "-Yno-adapted-args",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard",

--- a/core/src/main/scala/me/lightspeed7/crontab/ScheduleActor.scala
+++ b/core/src/main/scala/me/lightspeed7/crontab/ScheduleActor.scala
@@ -1,7 +1,7 @@
 package me.lightspeed7.crontab
 
 import java.time.LocalDateTime
-import java.time.temporal.{ChronoUnit, TemporalUnit}
+import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{Actor, ActorSystem}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.8

--- a/streams/src/main/scala/me/lightspeed7/crontab/StreamSource.scala
+++ b/streams/src/main/scala/me/lightspeed7/crontab/StreamSource.scala
@@ -10,10 +10,12 @@ import akka.stream.scaladsl.{Source, SourceQueueWithComplete}
 object StreamSource {
 
   def create(cron: Cron)(implicit system: ActorSystem): Source[LocalDateTime, NotUsed] = {
-    Source
-      .queue[LocalDateTime](1, OverflowStrategy.dropHead)
+    Source.queue[LocalDateTime](1, OverflowStrategy.dropHead)
       .mapMaterializedValue { queue: SourceQueueWithComplete[LocalDateTime] =>
-        system.actorOf(Props(classOf[ScheduleActor], CronConfig({ dt => queue.offer(dt) }, cron)))
+        system.actorOf(Props(classOf[ScheduleActor], CronConfig({ dt =>
+          queue.offer(dt)
+          ()
+        }, cron)))
         NotUsed
       }
   }

--- a/streams/src/test/scala/me/lightspeed7/crontab/StreamSourceTest.scala
+++ b/streams/src/test/scala/me/lightspeed7/crontab/StreamSourceTest.scala
@@ -22,8 +22,11 @@ class StreamSourceTest
   implicit val mat: ActorMaterializer = ActorMaterializer()
   implicit val ec: ExecutionContext = system.dispatcher
 
-  override def beforeAll: Unit = system.scheduler.schedule(0 seconds, 10 seconds) {
-    println(s"Dt = ${LocalDateTime.now}")
+  override def beforeAll: Unit = {
+    system.scheduler.schedule(0 seconds, 10 seconds) {
+      println(s"Dt = ${LocalDateTime.now}")
+    }
+    ()
   }
 
 


### PR DESCRIPTION
- Cross compiles for scala 2.11, 2.12 and 2.13.
- Minor code style deprecations
- Replaces Unicode character with standard arrow (=>), which is now flagged by Scala 2.13. For improved visuals use a font that supports ligatures like Fira Code.
- Bump version for release